### PR TITLE
Most of v1.0.0 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is a [TOML] parser. It supports TOML **0.2.0**, including
 arrays-of-tables, though it does not enforce type constraints on arrays.
 Work is in progress to bring this into compliance with v1.0.0.
-As of 2022-11-26 it passes 292/314 tests in [toml-test]. Click the
+As of 2022-11-27 it passes 297/322 tests in [toml-test]. Click the
 "TOML Compliance" badge for logs of toml-test.
 
 [TOML]: https://github.com/toml-lang/toml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is a [TOML] parser. It supports TOML **0.2.0**, including
 arrays-of-tables, though it does not enforce type constraints on arrays.
 Work is in progress to bring this into compliance with v1.0.0.
-As of 2022-11-27 it passes 297/322 tests in [toml-test]. Click the
+As of 2022-11-27 it passes 309/322 tests in [toml-test]. Click the
 "TOML Compliance" badge for logs of toml-test.
 
 [TOML]: https://github.com/toml-lang/toml

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![Tests](https://github.com/winny-/toml-racket/actions/workflows/tests.yml/badge.svg)](https://github.com/winny-/toml-racket/actions/workflows/tests.yml) [![TOML Compliance](https://github.com/winny-/toml-racket/actions/workflows/compliance.yml/badge.svg)](https://github.com/winny-/toml-racket/actions/workflows/compliance.yml) [![raco pkg install toml](https://img.shields.io/badge/raco%20pkg%20install-toml-purple)](https://pkgs.racket-lang.org/package/toml)
 
 
-This is a [TOML] parser. It supports TOML **0.2.0**, including
-arrays-of-tables, though it does not enforce type constraints on arrays.
-Work is in progress to bring this into compliance with v1.0.0.
-As of 2022-11-27 it passes 309/322 tests in [toml-test]. Click the
-"TOML Compliance" badge for logs of toml-test.
+This is a [TOML] parser, with dates supporting nanosecond precision. Work is
+in progress to bring this into compliance with v1.0.0. As of 2022-12-01 it
+passes 317/322 tests in [toml-test], including all tests that do not involve
+duplicate table rejection.
+Click the "TOML Compliance" badge for logs of toml-test.
 
 [TOML]: https://github.com/toml-lang/toml
 [toml-test]: https://github.com/BurntSushi/toml-test

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 
 This is a [TOML] parser. It supports TOML **0.2.0**, including
-arrays-of-tables. As of 2022-08-06 it passes 286/314 tests in [toml-test]
-(testing against version 0.4.0).  Click the "TOML Compliance" badge for logs of
-toml-test.
+arrays-of-tables, though it does not enforce type constraints on arrays.
+Work is in progress to bring this into compliance with v1.0.0.
+As of 2022-11-26 it passes 292/314 tests in [toml-test]. Click the
+"TOML Compliance" badge for logs of toml-test.
 
 [TOML]: https://github.com/toml-lang/toml
 [toml-test]: https://github.com/BurntSushi/toml-test
@@ -26,7 +27,7 @@ raco pkg install --auto toml
 
 ## Goals
 
-- Pass all [toml-test] tests for TOML **0.2.0**.
+- Pass all [toml-test] tests for TOML **1.0.0**.
 
 - Provide useful error messages with positions (line:col:ofs). Do so
   for both syntax errors and semantic errors (such as table

--- a/scripts/run-toml-test.bash
+++ b/scripts/run-toml-test.bash
@@ -33,10 +33,8 @@ cmd_default() {
     done
     shift $((OPTIND-1))
 
-    # My version of toml-test does not support 0.2.0
     cmd=(
         toml-test
-        -toml 0.4.0
         --
         racket -l toml/compliance/decoder
     )

--- a/toml-compliance/compliance/decoder.rkt
+++ b/toml-compliance/compliance/decoder.rkt
@@ -1,8 +1,9 @@
 #!/usr/bin/env racket
 #lang racket/base
 
-(require json
-         racket/date
+(require gregor
+         gregor/time
+         json
          racket/format
          racket/match
          racket/port
@@ -28,10 +29,14 @@
                                   [(nan? v) "nan"]
                                   [(infinite? v) (string-replace (~a v) ".0" "")]
                                   [else (~a v)]))]
-    [(? date? d) (hasheq 'type "datetime"
-                         'value
-                         (parameterize ([date-display-format 'iso-8601])
-                           (string-append (date->string d #t) "Z")))]
+    [(? moment? odt) (hasheq 'type "datetime"
+                             'value (moment->iso8601 odt))]
+    [(? datetime? ldt) (hasheq 'type "datetime-local"
+                               'value (datetime->iso8601 ldt))]
+    [(? date? ld) (hasheq 'type "date-local"
+                          'value (date->iso8601 ld))]
+    [(? time? lt) (hasheq 'type "time-local"
+                          'value (time->iso8601 lt))]
     [(? list? xs)
      (for/list ([x xs])
        (type-jsexpr x))]

--- a/toml-compliance/info.rkt
+++ b/toml-compliance/info.rkt
@@ -1,4 +1,4 @@
 #lang setup/infotab
-(define deps '("toml-lib" "base"))
+(define deps '("toml-lib" "gregor-lib" "base"))
 (define name "toml")
 (define collection "toml")

--- a/toml-lib/info.rkt
+++ b/toml-lib/info.rkt
@@ -2,6 +2,7 @@
 (define name "toml")
 (define collection "toml")
 (define deps '("base"
+               "gregor-lib"
                ["parsack-lib" "0.4"]))
 (define build-deps '("at-exp-lib"
                      "rackunit-lib"))

--- a/toml-lib/main.rkt
+++ b/toml-lib/main.rkt
@@ -3,7 +3,3 @@
 (require "private/parsers/main.rkt")
 
 (provide parse-toml)
-
-
-
-

--- a/toml-lib/private/parsack.rkt
+++ b/toml-lib/private/parsack.rkt
@@ -10,6 +10,7 @@
                   many many1
                   manyTill many1Till
                   manyUntil many1Until
+                  skipMany
                   sepBy sepBy1
                   oneOf noneOf oneOfStrings
                   option optional
@@ -33,6 +34,7 @@
          many many1
          manyTill many1Till
          manyUntil many1Until
+         skipMany
          sepBy sepBy1
          oneOf noneOf oneOfStrings
          option optional

--- a/toml-lib/private/parsers/literals.rkt
+++ b/toml-lib/private/parsers/literals.rkt
@@ -5,7 +5,6 @@
          racket/list
          racket/function
          racket/match
-         racket/math
 
          "../parsack.rkt"
          "../misc.rkt"

--- a/toml-lib/private/parsers/literals.rkt
+++ b/toml-lib/private/parsers/literals.rkt
@@ -24,12 +24,12 @@
               (>> (char #\n) (return #\newline))
               (>> (char #\r) (return #\return))
               (>> (char #\t) (return #\tab))
-                    (pdo (oneOf "uU")
-                         (cs <- (<or> (try (repetition $hexDigit 8))
-                                      (repetition $hexDigit 4)))
-                         (return
-                          (integer->char (string->number (list->string cs)
-                                                         16))))))
+              (pdo (oneOf "uU")
+                   (cs <- (<or> (try (repetition $hexDigit 8))
+                                (repetition $hexDigit 4)))
+                   (return
+                    (integer->char (string->number (list->string cs)
+                                                   16))))))
    "String escape sequence"))
 
 (define $basic-char
@@ -219,27 +219,23 @@
     (try
      (pdo $sp
           (char #\[)
-          $spnl (many $blank-or-comment-line) $sp
+          $ws-or-comments
           (v <- $val)
           (vs <- (many (try (pdo
-                             $spnl
+                             $ws-or-comments
                              (char #\,)
-                             $spnl
-                             (many $blank-or-comment-line)
-                             $sp
+                             $ws-or-comments
                              (vn <- $val)
                              (return vn)))))
-          $spnl
+          $ws-or-comments
           (optional (char #\,))
-          $spnl
-          (many $blank-or-comment-line)
-          $spnl
+          $ws-or-comments
           (char #\])
           (return (cons v vs))))
     (try
      (pdo $sp
           (char #\[)
-          $spnl (many $blank-or-comment-line)
+          $ws-or-comments
           (char #\])
           (return null))))
    "Array"))

--- a/toml-lib/private/parsers/literals.rkt
+++ b/toml-lib/private/parsers/literals.rkt
@@ -87,7 +87,7 @@
                  (optional $nl)
                  (cs <- (manyUntil $ml-content (try (string "\"\"\""))))
                  (extras <- (up-to-2 (char #\")))
-                 ; $ml-content returns null for line-ending backslash
+                 ;; $ml-content returns null for line-ending backslash
                  (return (list->string (append (filter char? cs) extras)))))
        "multi-line basic string"))
 

--- a/toml-lib/private/parsers/main.rkt
+++ b/toml-lib/private/parsers/main.rkt
@@ -23,7 +23,7 @@
 (define $kv-lines
   (many (pdo (kv <- $key/val)
              $sp-maybe-comment
-             ; HACK for last-line key/value pairs
+             ;; HACK for last-line key/value pairs
              (<or> $eof
                    (pdo $nl $ws-or-comments))
              (return kv))))
@@ -47,7 +47,7 @@
   (<?> (try (pdo (keys <- (between (char #\[) (char #\])
                                    (table-keys-under parent-keys)))
                  $sp-maybe-comment
-                 ; HACK to allow last-line headers
+                 ;; HACK to allow last-line headers
                  (<or> (pdo $eof
                             (return (kvs->hasheq keys '())))
                        (pdo $nl
@@ -65,7 +65,7 @@
   (<?> (try (pdo (keys <- (between (string "[[") (string "]]")
                                    (table-keys-under parent-keys)))
                  $sp-maybe-comment
-                 ; HACK to allow last-line headers
+                 ;; HACK to allow last-line headers
                  (<or> (pdo $eof
                             (return
                              (let* ([aot0 (merge (list (hasheq)) keys)])

--- a/toml-lib/private/parsers/main.rkt
+++ b/toml-lib/private/parsers/main.rkt
@@ -3,7 +3,6 @@
 (require racket/list
          racket/function
          racket/match
-         racket/math
          racket/port
 
          "../parsack.rkt"

--- a/toml-lib/private/parsers/main.rkt
+++ b/toml-lib/private/parsers/main.rkt
@@ -20,57 +20,6 @@
          (all-from-out "shared.rkt")
          (all-defined-out))
 
-;;; Keys for key = val pairs and for tables and arrays of tables
-
-(define $key-component
-  (pdo $sp
-       (v <-
-          (<or> (pdo (s <- (many1 (<or>
-                                   (char-range #\a #\z)
-                                   (char-range #\A #\Z)
-                                   $digit
-                                   (oneOf "_-"))))
-                     (return (list->string s)))
-                $lit-string
-                $basic-string))
-       $sp
-       (return (string->symbol v))))
-
-;; Valid chars for both normal keys and table keys
-(define (make-$key blame)
-  (<?>
-   (pdo (cs <- (sepBy1 $key-component (char #\.)))
-        (return cs))
-   blame))
-
-(define $common-key-char
-  (<or> $alphaNum (oneOf "_-")))
-
-(define $table-key-char
-  (<or> $common-key-char (oneOf " ")))
-
-(define $key-char
-  (<or> $common-key-char (oneOf "[].")))
-
-(define $table-key ;; >> symbol?
-  (<?> (pdo (cs <- (many1 $table-key-char))
-            (return (string->symbol (list->string cs))))
-       "table key"))
-
-(define $key ;; >> symbol?
-  (<?> (pdo (cs <- (many1 $key-char))
-            (return (string->symbol (list->string cs))))
-       "key"))
-
-(define $key/val ;; >> (list/c symbol? stx?)
-  (try (pdo (key <- (make-$key "key"))
-            $sp
-            (char #\=)
-            $sp
-            (pos <- (getPosition))
-            (val <- $val)
-            (return (list key (stx val pos))))))
-
 ;; Newline-delimited key/value pairs (as opposed to inline table-style)
 (define $kv-lines
   (many (pdo (kv <- $key/val)

--- a/toml-lib/private/parsers/shared.rkt
+++ b/toml-lib/private/parsers/shared.rkt
@@ -3,8 +3,6 @@
 (require racket/list
          racket/function
          racket/match
-         racket/math
-
 
          "../parsack.rkt"
          "../misc.rkt"

--- a/toml-lib/private/parsers/ws-comments.rkt
+++ b/toml-lib/private/parsers/ws-comments.rkt
@@ -3,7 +3,6 @@
 (require racket/list
          racket/function
          racket/match
-         racket/math
 
          "../parsack.rkt"
          "../misc.rkt"

--- a/toml-lib/private/parsers/ws-comments.rkt
+++ b/toml-lib/private/parsers/ws-comments.rkt
@@ -22,17 +22,8 @@
 
 (define $nl
   (<?> (<or> (string "\r\n")
-             (char #\newline))
-       "Newline (LF or CRLF"))
-
-(define $spnl
-  (<?> (pdo $sp (optional $nl) $sp
-            (return null))
-       "zero or more spaces, and optional newline plus zero or more spaces"))
-
-(define $blank-line
-  (<?> (try (pdo $sp $nl (return (void))))
-       "blank line"))
+             $newline)
+       "newline (LF or CRLF)"))
 
 (define $comment-char
   (<?> (<or> (char #\tab)
@@ -43,9 +34,13 @@
        "comment character"))
 
 (define $comment
-  (<?> (try (pdo $sp (char #\#) (manyUntil $comment-char $nl)
+  (<?> (try (pdo (char #\#) (manyUntil $comment-char (lookAhead (<or> $eof $nl)))
                  (return null)))
        "comment"))
 
-(define $blank-or-comment-line
-  (<or> $blank-line $comment))
+(define $sp-maybe-comment
+  (pdo $sp (optional $comment)))
+
+(define $ws-or-comments
+  (<?> (pdo (many (try (pdo $sp-maybe-comment $nl))) $sp)
+       "whitespace (possibly with comments)"))

--- a/toml-lib/private/tests/test-literals.rkt
+++ b/toml-lib/private/tests/test-literals.rkt
@@ -183,10 +183,19 @@ END
                (parse-toml "array2 = [1,]")
                #hasheq((array2 . (1))))
 
-  (test-equal? "Parse array literal with comment after trailingcomma"
+  (test-equal? "Parse array literal with comment after trailing comma"
                (parse-toml @~a{
                                array2 = [
                                          1, # test
+                                         ]
+                               })
+               #hasheq((array2 . (1))))
+
+  (test-equal? "Parse array literal with comment before trailing comma"
+               (parse-toml @~a{
+                               array2 = [
+                                         1 # test
+                                         ,
                                          ]
                                })
                #hasheq((array2 . (1))))
@@ -206,7 +215,8 @@ END
    (parse-toml @~a{
                    array2 = [ #comment
                               1, #comment
-                              2,
+                              2 # comments allowed before commas
+                              ,
                               3,
                               ] #comment
                    })

--- a/toml-lib/private/tests/test-literals.rkt
+++ b/toml-lib/private/tests/test-literals.rkt
@@ -276,7 +276,7 @@ END
    (hasheq 'ldt1 (datetime 1979 5 27 7 32)
            'ldt2 (datetime 1979 5 27 0 32 0 999999000)))
 
-  (test-equal? "Local date" ; FIXME
+  (test-equal? "Local date"
                (parse-result $datetime "1979-05-27")
                (date 1979 5 27))
 

--- a/toml-lib/private/tests/test-literals.rkt
+++ b/toml-lib/private/tests/test-literals.rkt
@@ -144,10 +144,32 @@ END
                (parse-toml "x = \"\"\"hello\\\nworld\"\"\"")
                `#hasheq((x . "helloworld")))
 
-  #;
+  (test-equal? "Line ending backslash from TOML v1.0.0"
+               (parse-result $ml-basic-string
+                             @~a{"""
+                                 The quick brown \
+
+
+                                   fox jumps over \  
+                                     the lazy dog."""})
+               "The quick brown fox jumps over the lazy dog.")
+
+  (test-equal? "Escaped newline with nothing after it"
+               (parse-result $ml-basic-string "\"\"\"\\\r\n\"\"\"")
+               "")
+
   (test-equal? "multiline basic string with tricky escape"
                (parse-toml @~a{multiline_end_esc = """When will it end? \"""...""\" should be here\""""})
                #hasheq((multiline_end_esc . "When will it end? \"\"\"...\"\"\" should be here\"")))
+
+  (test-equal? "Multiline literal string with single quotes"
+               (parse-result $ml-lit-string
+                             @~a{''''quotes' and more quotes!'''''})
+               "'quotes' and more quotes!''")
+
+  (test-exn "Too many apostrophes!"
+            exn:fail:parsack?
+            (thunk (parse-toml "apos15 = '''Here are fifteen apostrophes: ''''''''''''''''''")))
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ;; Array

--- a/toml-lib/private/tests/test-literals.rkt
+++ b/toml-lib/private/tests/test-literals.rkt
@@ -258,4 +258,12 @@ END
    (let ([t (date 0 45 17 5 7 1987 0 0 #f 0)])
      `#hasheq((a . ,t)
               (b . ,t)
-              (c . ,t)))))
+              (c . ,t))))
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ;; Inline Table
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (test-equal? "Simple standard/inline table should be the same"
+               (parse-toml "point = { x = 1, y = 2 }")
+               (parse-toml "[point]\nx = 1\ny = 2")))

--- a/toml-lib/private/tests/test-parse-toml.rkt
+++ b/toml-lib/private/tests/test-parse-toml.rkt
@@ -2,7 +2,6 @@
 
 (require gregor
          racket/function
-         json
 
          "../parsack.rkt"
          "../../main.rkt")

--- a/toml-lib/private/tests/test-parse-toml.rkt
+++ b/toml-lib/private/tests/test-parse-toml.rkt
@@ -1,6 +1,7 @@
 #lang at-exp racket/base
 
-(require racket/function
+(require gregor
+         racket/function
          json
 
          "../parsack.rkt"
@@ -14,7 +15,7 @@
   (check-equal? (parse-toml @~a{[a.b]})
                 '#hasheq((a . #hasheq((b . #hasheq())))))
   (check-equal? (parse-toml @~a{today = 2014-06-26T12:34:56Z})
-                `#hasheq((today . ,(date 56 34 12 26 6 2014 0 0 #f 0))))
+                `#hasheq((today . ,(moment 2014 6 26 12 34 56 #:tz 0))))
   ;; toml-tests: `duplicate-keys`
   (check-exn #rx"conflicting values for `x'"
              (λ () (parse-toml @~a{x=1

--- a/toml-lib/private/tests/test-shared.rkt
+++ b/toml-lib/private/tests/test-shared.rkt
@@ -1,9 +1,7 @@
 #lang at-exp racket/base
 
-
 (require racket/function
          racket/format
-         rackunit
 
          "../parsack.rkt"
 
@@ -11,6 +9,8 @@
          "../parsers/shared.rkt")
 
 (module+ test
+  (require rackunit)
+
   (test-not-exn "Parses emoji using $non-ascii"
                 (thunk (parse-result $non-ascii "😂")))
   (test-exn "$non-ascii Refuses bad byte"

--- a/toml-lib/private/tests/test-table.rkt
+++ b/toml-lib/private/tests/test-table.rkt
@@ -9,6 +9,20 @@
 
 (module+ test
   (require rackunit)
+
+  (test-exn "No line between table header and key"
+            exn:fail:parsack?
+            (thunk (parse-toml @~a{[header] key = "can't be same line"})))
+
+  (test-exn "No line between array table header and key"
+            exn:fail:parsack?
+            (thunk (parse-toml @~a{[[header]] key = "can't be same line"})))
+
+  ; Consider moving. Not really a table issue, but related to the above tests.
+  (test-exn "Keys need newlines"
+            exn:fail:parsack?
+            (thunk (parse-toml @~a{keys = "need" new = "lines"})))
+
   (test-equal? "Table with spaces between brackets"
                (parse-toml @~a{[ a ]
                                x = 1})

--- a/toml-lib/private/tests/test-table.rkt
+++ b/toml-lib/private/tests/test-table.rkt
@@ -18,7 +18,7 @@
             exn:fail:parsack?
             (thunk (parse-toml @~a{[[header]] key = "can't be same line"})))
 
-  ; Consider moving. Not really a table issue, but related to the above tests.
+  ;; Consider moving. Not really a table issue, but related to the above tests.
   (test-exn "Keys need newlines"
             exn:fail:parsack?
             (thunk (parse-toml @~a{keys = "need" new = "lines"})))

--- a/toml-lib/private/tests/test-ws-comments.rkt
+++ b/toml-lib/private/tests/test-ws-comments.rkt
@@ -11,8 +11,10 @@
 
 (module+ test
   (test-not-exn "Parses a comment with UTF-8 characters in it"
-                (thunk (parse-result $comment "# Hello world 😂
-")))
+                (thunk (parse-result $comment "# Hello world 😂\n")))
+
+  (test-not-exn "Parses a comment with UTF-8 characters in it, but no newline"
+                (thunk (parse-result $comment "# Hello world 😂")))
 
   (test-exn "Comment with control char is rejected"
             #rx".*comment.*"
@@ -20,6 +22,4 @@
 
   (test-exn "Comment with bad UTF-8 is rejected"
             #rx".*comment.*"
-            (thunk (parse-result $comment (open-input-bytes #"# Ã
-")))))
-
+            (thunk (parse-result $comment (open-input-bytes #"# Ã")))))

--- a/toml-lib/private/tests/test-ws-comments.rkt
+++ b/toml-lib/private/tests/test-ws-comments.rkt
@@ -1,15 +1,15 @@
 #lang at-exp racket/base
 
-
 (require racket/function
          racket/format
-         rackunit
 
          "../parsack.rkt"
 
          "../parsers/main.rkt")
 
 (module+ test
+  (require rackunit)
+
   (test-not-exn "Parses a comment with UTF-8 characters in it"
                 (thunk (parse-result $comment "# Hello world 😂\n")))
 


### PR DESCRIPTION
This should advance most of the way to v1.0.0 compliance, except for duplicate tables.  This covers the part of #6 that I could quickly resolve by extension or modification of the existing approaches.  With additional investigation, that might turn out to be reasonable as well, but I haven't looked yet.  I think this is a decent place to take stock and potentially merge.

I did add a dependency on `gregor`, given the greatly expanded datetime requirements of more recent TOML versions.

There's an optional tiny cleanup commit at the end.  I am open to revert (or do *more* of that type of cleanup), depending on preferences.