### PR TITLE
TOML v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 [![Tests](https://github.com/winny-/toml-racket/actions/workflows/tests.yml/badge.svg)](https://github.com/winny-/toml-racket/actions/workflows/tests.yml) [![TOML Compliance](https://github.com/winny-/toml-racket/actions/workflows/compliance.yml/badge.svg)](https://github.com/winny-/toml-racket/actions/workflows/compliance.yml) [![raco pkg install toml](https://img.shields.io/badge/raco%20pkg%20install-toml-purple)](https://pkgs.racket-lang.org/package/toml)
 
 
-This is a [TOML] parser, with dates supporting nanosecond precision. Work is
-in progress to bring this into compliance with v1.0.0. As of 2022-12-01 it
-passes 317/322 tests in [toml-test], including all tests that do not involve
-duplicate table rejection.
+This is a [TOML] parser, with dates supporting nanosecond precision. It
+passes all tests in [toml-test] v1.3.0.
 Click the "TOML Compliance" badge for logs of toml-test.
 
 [TOML]: https://github.com/toml-lang/toml
 [toml-test]: https://github.com/BurntSushi/toml-test
 
-This code is a fork of [Greg Hendershott's TOML parser](https://github.com/greghendershott/toml).  This version is available on pkgs.racket-lang.org.
+This code is a fork of [Greg Hendershott's TOML parser](https://github.com/greghendershott/toml).
+Unlike that repository, this version is available on pkgs.racket-lang.org.
 
 ## Installation
 

--- a/toml-lib/private/parsers/literals.rkt
+++ b/toml-lib/private/parsers/literals.rkt
@@ -25,9 +25,13 @@
               (>> (char #\n) (return #\newline))
               (>> (char #\r) (return #\return))
               (>> (char #\t) (return #\tab))
-              (pdo (oneOf "uU")
-                   (cs <- (<or> (try (repetition $hexDigit 8))
-                                (repetition $hexDigit 4)))
+              (pdo (char #\u)
+                   (cs <- (repetition $hexDigit 4))
+                   (return
+                    (integer->char (string->number (list->string cs)
+                                                   16))))
+              (pdo (char #\U)
+                   (cs <- (repetition $hexDigit 8))
                    (return
                     (integer->char (string->number (list->string cs)
                                                    16))))))
@@ -325,7 +329,7 @@
         (return cs))
    blame))
 
-(define $key/val ;; >> (list/c symbol? stx?)
+(define $key/val ;; >> (list/c (listof symbol?) stx?)
   (try (pdo (key <- (make-$key "key"))
             $sp
             (char #\=)
@@ -340,7 +344,7 @@
                  (kvs <- (sepBy $key/val (try (pdo $sp (char #\,) $sp))))
                  $sp
                  (char #\})
-                 (return (stx->dat (kvs->hasheq '() kvs)))))
+                 (return (stx->dat (kvs->hasheq kvs)))))
        "inline table"))
 
 (define $val

--- a/toml-lib/private/tests/test-literals.rkt
+++ b/toml-lib/private/tests/test-literals.rkt
@@ -98,9 +98,21 @@
                (parse-toml "x = \"\\u00d8\"")
                #hasheq((x . "Ø")))
 
+  (test-equal? "basic Str \\u escape should be exactly 4 hex digits"
+               (parse-toml "x = \"\\u00d80000\"")
+               #hasheq((x . "Ø0000")))
+
   (test-equal? "basic Str Accepts 8 hexdigit unicode escape"
-               (parse-toml "x = \"\\u000000d8\"")
+               (parse-toml "x = \"\\U000000d8\"")
                #hasheq((x . "Ø")))
+
+  (test-exn "basic Str rejects \\UXXXX (capital `U`) escape"
+            exn:fail:parsack?
+            (thunk (parse-toml "x = \"\\U00d8\"")))
+
+  (test-exn "basic Str requires \\U escape to be 8 hex digits"
+            exn:fail:parsack?
+            (thunk (parse-toml "x = \"\\U0123456\"")))
 
   (test-equal? "Escaped Str \"foo bar baz\""
                (parse-toml "x = \"foo bar baz\"")
@@ -187,11 +199,11 @@ END
 
   (test-equal? "ar0 = [1,2,3]"
                (parse-toml "ar0 = [1,2,3]")
-                #hasheq((ar0 . (1 2 3))))
+               #hasheq((ar0 . (1 2 3))))
 
   (test-equal? "ar0 = [ 1, 2, 3] "
-                (parse-toml "ar0 = [ 1, 2, 3] ")
-                #hasheq((ar0 . (1 2 3))))
+               (parse-toml "ar0 = [ 1, 2, 3] ")
+               #hasheq((ar0 . (1 2 3))))
 
   (test-equal? "Parse empty array w whitespace inside"
                (parse-toml "ar0 = [ ]")


### PR DESCRIPTION
Resolves duplicate tables via carrying some table metadata in a custom struct. This enables discernment of the case where headers are duplicated but stored values do not conflict, including cases where the conflict is with dotted keys. Pre-commit versions required leaves to be in conflict in order to raise errors.

Also updates Unicode escapes, conforming to specifications that require `\u` escapes to be followed by exactly 4 hex digits and and `\U` exactly 8.

Resolves #6.