### PR TITLE
Add CI fixes to the "docs" branch

### DIFF
--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -27,4 +27,5 @@ ins() {
 
 ins toml-lib
 ins toml-compliance
+ins toml-doc
 ins toml

--- a/toml-doc/info.rkt
+++ b/toml-doc/info.rkt
@@ -4,5 +4,4 @@
 
 (define build-deps '("base"
                      "scribble-lib"
-                     "toml-lib"
-                     "json"))
+                     "toml-lib"))


### PR DESCRIPTION
Package resolution is handled manually in CI - this assures packages are installed from the git checkout.  The solution was to add an `ins toml-doc` line to the script used to install the packages to be tested.

I also removed a reference to `json`, to the best of my knowledge this is shipped in `base`.